### PR TITLE
Add FastAPI REST API

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,26 @@ Estado emocional: 1
 
 No ciclo seguinte, após nova ação, o histórico muda e o estado emocional é
 ajustado conforme o sucesso ou falha, alterando também o prompt enviado.
+
+## API REST
+
+A aplicação possui uma API REST construída com **FastAPI** disponível no arquivo `api.py`.
+Para utilizar instale as dependências e execute o servidor com o `uvicorn`:
+
+```bash
+pip install -r requirements.txt
+uvicorn api:app --reload
+```
+
+Os principais endpoints retornam dados em JSON:
+
+- `GET /agentes` – lista todos os agentes cadastrados.
+- `POST /agentes` – cria um novo agente.
+- `PUT /agentes/{nome}` – atualiza informações ou move o agente de local.
+- `DELETE /agentes/{nome}` – remove o agente.
+- `GET /locais` – mostra todas as salas e quem está em cada uma.
+- `POST /locais` – cria uma nova sala.
+- `PUT /locais/{nome}` – edita a sala existente.
+- `DELETE /locais/{nome}` – exclui a sala.
+- `POST /ciclo/next` – executa um novo ciclo da simulação para todos os agentes.
+

--- a/api.py
+++ b/api.py
@@ -1,0 +1,207 @@
+from typing import List, Optional
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+
+from empresa_digital import (
+    Agente,
+    Local,
+    agentes,
+    locais,
+    criar_agente,
+    criar_local,
+    mover_agente,
+    gerar_prompt_decisao,
+    enviar_para_llm,
+    executar_resposta,
+)
+
+# Instância principal da aplicação FastAPI
+app = FastAPI(title="Empresa Digital API")
+
+
+def agente_to_dict(ag: Agente) -> dict:
+    """Converte um agente para um dicionário serializável."""
+    return {
+        "nome": ag.nome,
+        "funcao": ag.funcao,
+        "modelo_llm": ag.modelo_llm,
+        "local_atual": ag.local_atual.nome if ag.local_atual else None,
+        "historico_acoes": ag.historico_acoes,
+        "historico_interacoes": ag.historico_interacoes,
+        "historico_locais": ag.historico_locais,
+        "objetivo_atual": ag.objetivo_atual,
+        "feedback_ceo": ag.feedback_ceo,
+        "estado_emocional": ag.estado_emocional,
+    }
+
+
+def local_to_dict(loc: Local) -> dict:
+    """Converte um local para um dicionário serializável."""
+    return {
+        "nome": loc.nome,
+        "descricao": loc.descricao,
+        "inventario": loc.inventario,
+        "agentes_presentes": [a.nome for a in loc.agentes_presentes],
+    }
+
+
+class AgentIn(BaseModel):
+    """Modelo de dados para criar agentes."""
+
+    nome: str
+    funcao: str
+    modelo_llm: str
+    local: str
+    objetivo: Optional[str] = ""
+
+
+class AgentUpdate(BaseModel):
+    """Modelo para atualizar atributos de um agente."""
+
+    funcao: Optional[str] = None
+    modelo_llm: Optional[str] = None
+    local: Optional[str] = None
+    objetivo: Optional[str] = None
+    feedback_ceo: Optional[str] = None
+
+
+class LocalIn(BaseModel):
+    """Modelo de dados para criar locais."""
+
+    nome: str
+    descricao: str
+    inventario: Optional[List[str]] = None
+
+
+class LocalUpdate(BaseModel):
+    """Modelo de dados para atualizar locais."""
+
+    descricao: Optional[str] = None
+    inventario: Optional[List[str]] = None
+
+
+# ---------------------------- Endpoints de agentes ----------------------------
+@app.get("/agentes")
+async def listar_agentes():
+    """Retorna todos os agentes e suas informações."""
+    return [agente_to_dict(a) for a in agentes.values()]
+
+
+@app.get("/agentes/{nome}")
+async def obter_agente(nome: str):
+    """Recupera um único agente pelo nome."""
+    ag = agentes.get(nome)
+    if ag is None:
+        raise HTTPException(status_code=404, detail="Agente nao encontrado")
+    return agente_to_dict(ag)
+
+
+@app.post("/agentes", status_code=201)
+async def criar_agente_endpoint(dados: AgentIn):
+    """Cria um novo agente."""
+    if dados.nome in agentes:
+        raise HTTPException(status_code=400, detail="Agente ja existe")
+    criar_agente(
+        dados.nome,
+        dados.funcao,
+        dados.modelo_llm,
+        dados.local,
+        dados.objetivo,
+    )
+    return agente_to_dict(agentes[dados.nome])
+
+
+@app.put("/agentes/{nome}")
+async def editar_agente(nome: str, dados: AgentUpdate):
+    """Edita atributos de um agente existente."""
+    ag = agentes.get(nome)
+    if ag is None:
+        raise HTTPException(status_code=404, detail="Agente nao encontrado")
+    if dados.funcao is not None:
+        ag.funcao = dados.funcao
+    if dados.modelo_llm is not None:
+        ag.modelo_llm = dados.modelo_llm
+    if dados.objetivo is not None:
+        ag.objetivo_atual = dados.objetivo
+    if dados.feedback_ceo is not None:
+        ag.feedback_ceo = dados.feedback_ceo
+    if dados.local is not None:
+        mover_agente(nome, dados.local)
+    return agente_to_dict(ag)
+
+
+@app.delete("/agentes/{nome}")
+async def remover_agente(nome: str):
+    """Remove um agente do sistema."""
+    ag = agentes.pop(nome, None)
+    if ag is None:
+        raise HTTPException(status_code=404, detail="Agente nao encontrado")
+    if ag.local_atual:
+        ag.local_atual.remover_agente(ag)
+    return {"ok": True}
+
+
+# ------------------------------ Endpoints locais -----------------------------
+@app.get("/locais")
+async def listar_locais():
+    """Lista todos os locais e quem está em cada um."""
+    return [local_to_dict(l) for l in locais.values()]
+
+
+@app.get("/locais/{nome}")
+async def obter_local(nome: str):
+    """Recupera um local específico."""
+    loc = locais.get(nome)
+    if loc is None:
+        raise HTTPException(status_code=404, detail="Local nao encontrado")
+    return local_to_dict(loc)
+
+
+@app.post("/locais", status_code=201)
+async def criar_local_endpoint(dados: LocalIn):
+    """Cria um novo local."""
+    if dados.nome in locais:
+        raise HTTPException(status_code=400, detail="Local ja existe")
+    criar_local(dados.nome, dados.descricao, dados.inventario)
+    return local_to_dict(locais[dados.nome])
+
+
+@app.put("/locais/{nome}")
+async def editar_local(nome: str, dados: LocalUpdate):
+    """Edita um local existente."""
+    loc = locais.get(nome)
+    if loc is None:
+        raise HTTPException(status_code=404, detail="Local nao encontrado")
+    if dados.descricao is not None:
+        loc.descricao = dados.descricao
+    if dados.inventario is not None:
+        loc.inventario = dados.inventario
+    return local_to_dict(loc)
+
+
+@app.delete("/locais/{nome}")
+async def remover_local(nome: str):
+    """Remove um local do sistema."""
+    loc = locais.pop(nome, None)
+    if loc is None:
+        raise HTTPException(status_code=404, detail="Local nao encontrado")
+    # Desassocia agentes que estavam presentes
+    for ag in list(loc.agentes_presentes):
+        ag.local_atual = None
+        loc.remover_agente(ag)
+    return {"ok": True}
+
+
+# ---------------------------- Controle da simulação ---------------------------
+@app.post("/ciclo/next")
+async def proximo_ciclo():
+    """Executa um ciclo para todos os agentes cadastrados."""
+    resultados = []
+    for ag in agentes.values():
+        prompt = gerar_prompt_decisao(ag)
+        resp = enviar_para_llm(ag, prompt)
+        executar_resposta(ag, resp)
+        resultados.append(agente_to_dict(ag))
+    return {"agentes": resultados}
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn


### PR DESCRIPTION
## Summary
- implement FastAPI API to list/create/update agents and rooms
- support running simulation cycle via `/ciclo/next`
- document new API usage in README
- add package requirements

## Testing
- `python -m py_compile empresa_digital.py api.py`

------
https://chatgpt.com/codex/tasks/task_e_684716dfdbb88320a989b445e2dff555