### PR TITLE
Add draggable company map

### DIFF
--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { Button } from './components/ui/Button'
 import { Input } from './components/ui/Input'
 import { Card } from './components/ui/Card'
+import { CompanyMap } from './components/CompanyMap'
 
 interface Agent {
   id: number
@@ -106,6 +107,25 @@ export default function App() {
     setNewSala({})
   }
 
+  function handleMoveAgent(id: number, sala: string) {
+    setAgents(prev =>
+      prev.map(a => (a.id === id ? { ...a, salaAtual: sala } : a))
+    )
+    const ag = agents.find(a => a.id === id)
+    if (ag) {
+      setTimeline(prev => [
+        {
+          id: Date.now(),
+          agente: ag.nome,
+          acao: 'Arrasto',
+          sala,
+          motivo: 'Movido manualmente'
+        },
+        ...prev
+      ].slice(0, 50))
+    }
+  }
+
   function proximoCiclo() {
     const eventos: TimelineItem[] = []
     setAgents(prev => {
@@ -183,6 +203,11 @@ export default function App() {
           </Card>
 
       </div>
+
+      <Card>
+        <h2 className="text-xl font-semibold mb-2">Mapa da Empresa</h2>
+        <CompanyMap agentes={agents} salas={salas} onMove={handleMoveAgent} />
+      </Card>
 
       <div className="flex space-x-6">
         <Card className="flex-1">

--- a/dashboard/src/components/CompanyMap.tsx
+++ b/dashboard/src/components/CompanyMap.tsx
@@ -1,0 +1,57 @@
+import { Card } from './ui/Card'
+
+export interface Agent {
+  id: number
+  nome: string
+  salaAtual: string
+}
+
+export interface Sala {
+  id: number
+  nome: string
+}
+
+export interface CompanyMapProps {
+  agentes: Agent[]
+  salas: Sala[]
+  onMove: (agenteId: number, salaNome: string) => void
+}
+
+export function CompanyMap({ agentes, salas, onMove }: CompanyMapProps) {
+  function handleDrop(e: React.DragEvent<HTMLDivElement>, sala: Sala) {
+    e.preventDefault()
+    const id = Number(e.dataTransfer.getData('text'))
+    if (!id) return
+    onMove(id, sala.nome)
+  }
+
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+      {salas.map((s) => (
+        <Card
+          key={s.id}
+          onDragOver={(e) => e.preventDefault()}
+          onDrop={(e) => handleDrop(e, s)}
+          className="min-h-[120px]"
+        >
+          <h3 className="font-semibold mb-2">{s.nome}</h3>
+          <div className="space-y-1">
+            {agentes.filter((a) => a.salaAtual === s.nome).map((a) => (
+              <div
+                key={a.id}
+                draggable
+                onDragStart={(e) => e.dataTransfer.setData('text', String(a.id))}
+                className="cursor-move px-2 py-1 bg-gray-100 rounded"
+              >
+                {a.nome}
+              </div>
+            ))}
+            {agentes.filter((a) => a.salaAtual === s.nome).length === 0 && (
+              <p className="text-sm text-gray-500">Vazio</p>
+            )}
+          </div>
+        </Card>
+      ))}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- map rooms and agents visually
- drag agents to move them between rooms
- show map under add forms

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684718a04d9083209ff3e45d261aa7b8