### PR TITLE
Implement virtual profit tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Colegas presentes: Bob
 Inventário disponível: computadores, ferramentas de rede
 Outros locais disponíveis: Sala de Reunião
 
+Seu objetivo final é maximizar o lucro da empresa.
+
 Escolha UMA das ações a seguir e responda apenas em JSON:
 1. 'ficar' - permanecer no local atual.
 2. 'mover' - ir para outro local. Use o campo 'local' com o destino.
@@ -86,6 +88,21 @@ tarefas registradas em `tarefas_pendentes`, o módulo cria automaticamente um
 novo agente (com nome e modelo padrão) e registra a contratação no log. Os
 agentes gerados participam normalmente dos próximos ciclos e aparecem no
 dashboard. Novas tarefas podem ser adicionadas pela função `adicionar_tarefa`.
+
+## Lucro virtual
+
+Cada ciclo contabiliza receitas e custos gerando um **saldo** global. A receita
+é obtida quando agentes executam ações com sucesso (10 unidades por ação) e os
+custos incluem um salário fixo de 5 por agente mais 1 unidade por recurso da
+sala utilizada. O histórico do saldo é registrado e exibido no dashboard.
+
+O RH somente contrata novos agentes quando o saldo é positivo e existem tarefas
+pendentes, sinalizando perspectiva de aumento de lucro. Os prompts de decisão e
+de contexto informam que o objetivo principal é *maximizar o lucro da empresa*.
+
+Exemplo: se o saldo estiver baixo, o RH não abrirá vagas extras mesmo que uma
+sala esteja vazia. Já com saldo alto e tarefas pendentes, novos agentes são
+criados para acelerar a entrega de MVPs e gerar mais receita.
 
 ## API REST
 

--- a/api.py
+++ b/api.py
@@ -8,6 +8,9 @@ from empresa_digital import (
     Local,
     agentes,
     locais,
+    saldo,
+    historico_saldo,
+    calcular_lucro_ciclo,
     criar_agente,
     criar_local,
     mover_agente,
@@ -206,5 +209,10 @@ async def proximo_ciclo():
         resp = enviar_para_llm(ag, prompt)
         executar_resposta(ag, resp)
         resultados.append(agente_to_dict(ag))
-    return {"agentes": resultados}
+    lucro_info = calcular_lucro_ciclo()
+    return {
+        "agentes": resultados,
+        "saldo": lucro_info["saldo"],
+        "historico_saldo": historico_saldo,
+    }
 

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -45,6 +45,8 @@ export default function App() {
   const [newAgent, setNewAgent] = useState<{ nome?: string; funcao?: string; modelo?: string; sala?: string }>({})
   const [newSala, setNewSala] = useState<Partial<Sala>>({})
   const [timeline, setTimeline] = useState<TimelineItem[]>([])
+  const [saldo, setSaldo] = useState<number>(0)
+  const [historicoSaldo, setHistoricoSaldo] = useState<number[]>([])
 
   async function loadData() {
     const ag = await fetch(`${API_URL}/agentes`).then(r => r.json())
@@ -107,11 +109,12 @@ export default function App() {
     }
   }
 
-  function proximoCiclo() {
   async function proximoCiclo() {
     const prev = agents
     const data = await fetch(`${API_URL}/ciclo/next`, { method: 'POST' }).then(r => r.json())
     setAgents(data.agentes)
+    setSaldo(data.saldo)
+    setHistoricoSaldo(data.historico_saldo)
 
     const eventos: TimelineItem[] = []
     data.agentes.forEach((a: Agent) => {
@@ -230,6 +233,15 @@ export default function App() {
                 </p>
                 <p className="text-xs text-gray-600">{ev.motivo}</p>
               </div>
+            ))}
+          </div>
+        </Card>
+        <Card className="flex-1">
+          <h2 className="text-xl font-semibold mb-2">Lucro</h2>
+          <p className="text-sm">Saldo atual: {saldo.toFixed(2)}</p>
+          <div className="mt-2 space-y-1 max-h-96 overflow-auto text-xs">
+            {historicoSaldo.map((v, i) => (
+              <div key={i}>{i + 1}: {v.toFixed(2)}</div>
             ))}
           </div>
         </Card>


### PR DESCRIPTION
## Summary
- track company balance and history in `empresa_digital`
- add profit calculation to each cycle and include in API
- hire new agents only when the balance is positive
- show balance history on the React dashboard
- document how profit works in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68472112f1348320a79857dbafd709eb