### PR TITLE
Implement startup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,3 +168,27 @@ npm run dev
 ```
 
 O mapa e as tabelas são atualizados a cada ciclo disparado pelo botão "Próximo ciclo" e apenas refletem as decisões automáticas do backend.
+
+## Inicializador Automático
+
+Para subir todo o sistema com um único comando existe o script `start_empresa.py`.
+Ele instala dependências, solicita a chave da OpenRouter na primeira execução e
+inicia backend e frontend de forma integrada:
+
+```bash
+python start_empresa.py
+```
+
+Etapas realizadas pelo script:
+
+1. Caso não exista o arquivo `.openrouter_key`, pede a sua API Key e salva
+   localmente.
+2. Instala os pacotes Python listados em `requirements.txt`.
+3. Garante que as dependências do dashboard estejam instaladas (`npm install`).
+4. Inicia o backend na porta 8000 e aguarda ele ficar disponível.
+5. Inicia o frontend na porta 5173 e mostra os endereços de acesso.
+6. Consulta a API para informar quais agentes e salas foram criados
+   automaticamente.
+
+Após a primeira execução a chave é reutilizada e o sistema pode ser iniciado
+novamente apenas rodando o mesmo comando.

--- a/start_empresa.py
+++ b/start_empresa.py
@@ -1,0 +1,86 @@
+import os
+import sys
+import time
+from pathlib import Path
+from getpass import getpass
+import subprocess
+import requests
+
+ROOT = Path(__file__).parent
+BACKEND_PORT = os.environ.get("BACKEND_PORT", "8000")
+FRONTEND_PORT = os.environ.get("FRONTEND_PORT", "5173")
+KEY_FILE = ROOT / ".openrouter_key"
+
+
+def ensure_api_key() -> None:
+    """Solicita e armazena a API Key da OpenRouter na primeira execucao."""
+    if KEY_FILE.exists():
+        key = KEY_FILE.read_text().strip()
+    else:
+        key = getpass("Digite sua OpenRouter API Key: ")
+        KEY_FILE.write_text(key)
+    os.environ["OPENROUTER_API_KEY"] = key
+
+
+def install_dependencies() -> None:
+    """Instala dependencias do backend e frontend se necessario."""
+    subprocess.run([sys.executable, "-m", "pip", "install", "-r", "requirements.txt"], check=True)
+    node_modules = ROOT / "dashboard" / "node_modules"
+    if not node_modules.exists():
+        subprocess.run(["npm", "install"], cwd=ROOT / "dashboard", check=True)
+
+
+def wait_backend(port: str, timeout: int = 30) -> bool:
+    url = f"http://localhost:{port}/locais"
+    for _ in range(timeout):
+        try:
+            requests.get(url, timeout=1)
+            return True
+        except Exception:
+            time.sleep(1)
+    return False
+
+
+def show_status(port: str) -> None:
+    try:
+        ag = requests.get(f"http://localhost:{port}/agentes", timeout=5).json()
+        loc = requests.get(f"http://localhost:{port}/locais", timeout=5).json()
+        print("Agentes criados:", ", ".join(a["nome"] for a in ag))
+        print("Salas criadas:", ", ".join(l["nome"] for l in loc))
+    except Exception as exc:
+        print("Nao foi possivel obter informacoes iniciais:", exc)
+
+
+def main() -> None:
+    ensure_api_key()
+    install_dependencies()
+
+    backend_cmd = [sys.executable, "-m", "uvicorn", "api:app", "--reload", "--port", BACKEND_PORT]
+    backend = subprocess.Popen(backend_cmd)
+    if not wait_backend(BACKEND_PORT):
+        print("Backend nao respondeu a tempo.")
+        backend.terminate()
+        return
+    print(f"Backend rodando em http://localhost:{BACKEND_PORT}")
+    show_status(BACKEND_PORT)
+
+    frontend_cmd = ["npm", "run", "dev", "--", "--port", FRONTEND_PORT]
+    frontend = subprocess.Popen(frontend_cmd, cwd=ROOT / "dashboard")
+    print(f"Frontend acessivel em http://localhost:{FRONTEND_PORT}")
+
+    try:
+        while True:
+            time.sleep(1)
+            if backend.poll() is not None or frontend.poll() is not None:
+                break
+    except KeyboardInterrupt:
+        pass
+    finally:
+        frontend.terminate()
+        backend.terminate()
+        frontend.wait()
+        backend.wait()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `start_empresa.py` to initialize backend and frontend
- document single-command setup in README

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684751c16c04832087b1a291c5a0d781