### PR TITLE
Init cycle auto start + live events

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,13 @@ Etapas realizadas pelo script:
 5. Inicia o frontend na porta 5173 e mostra os endereços de acesso.
 6. Consulta a API para informar quais agentes e salas foram criados
    automaticamente.
+7. Dispara automaticamente o primeiro ciclo da simulação e envia os eventos
+   iniciais para o dashboard.
 
 Após a primeira execução a chave é reutilizada e o sistema pode ser iniciado
 novamente apenas rodando o mesmo comando.
+
+Durante o carregamento o dashboard exibe a mensagem **"Carregando/Iniciando a
+empresa..."**. Assim que o backend responde, a interface mostra as salas,
+agentes e um painel de eventos em tempo real demonstrando o raciocínio e as
+decisões de cada agente.

--- a/ciclo_criativo.py
+++ b/ciclo_criativo.py
@@ -2,7 +2,7 @@ import logging
 from dataclasses import dataclass
 from typing import List, Dict
 
-from empresa_digital import agentes, adicionar_tarefa
+from empresa_digital import agentes, adicionar_tarefa, registrar_evento
 
 logger = logging.getLogger(__name__)
 
@@ -37,6 +37,7 @@ def propor_ideias() -> List[Ideia]:
             ideia = Ideia(descricao=desc, justificativa=justificativa, autor=ag.nome)
             ideias.append(ideia)
             logger.info("Ideia proposta: %s", desc)
+            registrar_evento(f"Ideia proposta: {desc}")
     return ideias
 
 
@@ -51,6 +52,9 @@ def validar_ideias(ideias: List[Ideia]) -> None:
                 ideia.descricao,
                 val.nome,
                 "aprovada" if aprovado else "reprovada",
+            )
+            registrar_evento(
+                f"Validacao de {ideia.descricao} por {val.nome}: {'aprovada' if aprovado else 'reprovada'}"
             )
             if aprovado:
                 ideia.validada = True
@@ -72,6 +76,9 @@ def prototipar_ideias(ideias: List[Ideia]) -> None:
             "Prototipo de %s resultou em %.2f",
             ideia.descricao,
             ideia.resultado,
+        )
+        registrar_evento(
+            f"Prototipo de {ideia.descricao} resultou em {ideia.resultado:.2f}"
         )
 
 

--- a/rh.py
+++ b/rh.py
@@ -14,6 +14,7 @@ from empresa_digital import (
     tarefas_pendentes,
     saldo,
     selecionar_modelo,
+    registrar_evento,
 )
 
 logger = logging.getLogger(__name__)
@@ -37,6 +38,7 @@ class ModuloRH:
         """Verifica carencias e contrata novos agentes se necessario."""
         if saldo <= 0:
             logger.info("Saldo insuficiente, nenhuma contratacao realizada")
+            registrar_evento("RH: saldo insuficiente para contratar")
             return
 
         contratou = False
@@ -47,12 +49,14 @@ class ModuloRH:
                 nome = self._novo_nome()
                 modelo, motivo = selecionar_modelo("Funcionario")
                 criar_agente(nome, "Funcionario", modelo, local.nome)
+                msg = f"RH contratou {nome} para {local.nome} - {motivo}"
                 logger.info(
                     "Novo agente %s alocado em %s por falta de pessoal - %s",
                     nome,
                     local.nome,
                     motivo,
                 )
+                registrar_evento(msg)
                 contratou = True
 
         # Conta agentes por funcao
@@ -66,6 +70,9 @@ class ModuloRH:
                 if primeiro_local:
                     modelo, motivo = selecionar_modelo(funcao)
                     criar_agente(nome, funcao, modelo, primeiro_local.nome)
+                    msg = (
+                        f"RH contratou {nome} para funcao {funcao} - {motivo}"
+                    )
                     logger.info(
                         "Novo agente %s contratado para funcao %s (apenas %d existentes) - %s",
                         nome,
@@ -73,6 +80,7 @@ class ModuloRH:
                         qtd,
                         motivo,
                     )
+                    registrar_evento(msg)
                     contratou = True
 
         # Cria agentes para tarefas pendentes
@@ -89,16 +97,19 @@ class ModuloRH:
                     primeiro_local.nome,
                     objetivo=tarefa,
                 )
+                msg = f"RH criou {nome} para tarefa '{tarefa}' - {motivo}"
                 logger.info(
                     "Agente %s criado para tarefa pendente '%s' - %s",
                     nome,
                     tarefa,
                     motivo,
                 )
+                registrar_evento(msg)
                 contratou = True
 
         if not contratou:
             logger.info("Nenhuma contratacao necessaria neste ciclo")
+            registrar_evento("RH: nenhuma contratacao necessaria")
 
 
 modulo_rh = ModuloRH()

--- a/start_empresa.py
+++ b/start_empresa.py
@@ -63,6 +63,11 @@ def main() -> None:
         return
     print(f"Backend rodando em http://localhost:{BACKEND_PORT}")
     show_status(BACKEND_PORT)
+    # Gatilho do primeiro ciclo automatico logo apos o backend iniciar
+    try:
+        requests.post(f"http://localhost:{BACKEND_PORT}/ciclo/next", timeout=5)
+    except Exception as exc:
+        print("Falha ao disparar ciclo inicial:", exc)
 
     frontend_cmd = ["npm", "run", "dev", "--", "--port", FRONTEND_PORT]
     frontend = subprocess.Popen(frontend_cmd, cwd=ROOT / "dashboard")


### PR DESCRIPTION
## Summary
- track events for frontend feedback
- start first cycle automatically on API startup
- expose /eventos endpoint and include events in `/ciclo/next`
- trigger initial cycle from `start_empresa.py`
- show loading screen and real-time events on dashboard
- document new automatic behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684754b6bbcc8320af3ad23aab7135b7