### PR TITLE
Add extended automated testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,3 +199,32 @@ Durante o carregamento o dashboard exibe a mensagem **"Carregando/Iniciando a
 empresa..."**. Assim que o backend responde, a interface mostra as salas,
 agentes e um painel de eventos em tempo real demonstrando o raciocínio e as
 decisões de cada agente.
+
+## Testes Automatizados
+
+Uma bateria de testes em `pytest` valida as partes isoladas do sistema e o comportamento integrado.
+
+Para executar todos os testes:
+
+```bash
+# instalar dependências do backend e o pytest
+pip install -r requirements.txt pytest
+
+# rodar a suíte (é importante incluir o diretório raiz no PYTHONPATH)
+PYTHONPATH=. pytest -q
+```
+
+O relatório exibirá quantos testes foram executados e possíveis falhas. Os testes
+estão organizados em:
+
+- `tests/test_core.py` e `tests/test_llm.py` – verificações unitárias das funções
+  principais e da heurística de seleção de modelos.
+- `tests/test_integration.py`, `tests/test_simulation.py` e `tests/test_rh_auto.py`
+  – integração entre módulos como RH, ciclo criativo e cálculo de lucro.
+- `tests/test_end_to_end.py` e `tests/test_frontend_api.py` – simulam a
+  inicialização completa e ciclos via API, garantindo atualização da interface.
+- `tests/test_resilience.py` – cenários de erro e validação de mensagens.
+
+Todos devem passar indicando que a empresa digital consegue se comportar de forma
+autônoma e resiliente.
+

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -1,0 +1,26 @@
+from fastapi.testclient import TestClient
+import api
+import empresa_digital as ed
+
+
+def test_startup_creates_company(reset_state):
+    """Inicializa a API e verifica se agentes e salas foram criados."""
+    with TestClient(api.app) as client:
+        agentes = client.get("/agentes").json()
+        locais = client.get("/locais").json()
+        assert len(agentes) >= 3
+        assert len(locais) >= 2
+        assert ed.historico_saldo  # saldo calculado no startup
+
+
+def test_multiple_cycles_autonomous(reset_state):
+    """Executa múltiplos ciclos e verifica evolução do saldo e ideias."""
+    with TestClient(api.app) as client:
+        saldos = []
+        for _ in range(3):
+            resp = client.post("/ciclo/next")
+            assert resp.status_code == 200
+            saldos.append(resp.json()["saldo"])
+        assert len(ed.historico_saldo) >= 3
+        assert saldos[-1] != saldos[0]
+        assert any(i for i in resp.json()["ideias"])

--- a/tests/test_frontend_api.py
+++ b/tests/test_frontend_api.py
@@ -1,0 +1,20 @@
+from fastapi.testclient import TestClient
+import api
+import empresa_digital as ed
+
+
+def test_event_endpoint_updates(reset_state):
+    """Após um ciclo a API de eventos deve retornar informacoes."""
+    client = TestClient(api.app)
+    client.post("/locais", json={"nome": "Lab", "descricao": "", "inventario": []})
+    client.post(
+        "/agentes",
+        json={"nome": "A", "funcao": "Ideacao", "modelo_llm": "gpt", "local": "Lab"},
+    )
+    client.post(
+        "/agentes",
+        json={"nome": "B", "funcao": "Validador", "modelo_llm": "gpt", "local": "Lab"},
+    )
+    client.post("/ciclo/next")
+    eventos = client.get("/eventos").json()
+    assert eventos

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -1,0 +1,16 @@
+import empresa_digital as ed
+
+
+def test_auto_initialization_creates_resources(reset_state):
+    """Verifica se a inicialização automática gera salas, agentes e tarefas."""
+    ed.inicializar_automaticamente()
+    assert ed.locais
+    assert ed.agentes
+    assert ed.tarefas_pendentes
+
+
+def test_model_selection_heuristics():
+    """Garante que a escolha do modelo LLM segue a heurística esperada."""
+    assert ed.selecionar_modelo("Dev")[0] == "deepseek-chat"
+    assert ed.selecionar_modelo("CEO")[0] == "phi-4:free"
+    assert ed.selecionar_modelo("Outro")[0] == "gpt-3.5-turbo"

--- a/tests/test_resilience.py
+++ b/tests/test_resilience.py
@@ -1,0 +1,27 @@
+from fastapi.testclient import TestClient
+import api
+import empresa_digital as ed
+import ciclo_criativo
+import pytest
+
+
+def test_modelos_livres_error_logging(monkeypatch):
+    """Simula falha ao buscar modelos e checa se a API responde com erro."""
+    def fail(*_, **__):
+        raise RuntimeError("falha")
+    monkeypatch.setattr(api, "_buscar_modelos_gratis", fail)
+    client = TestClient(api.app)
+    resp = client.get("/modelos-livres")
+    assert resp.status_code == 500
+
+
+def test_ciclo_next_failure(monkeypatch, reset_state):
+    """Se algum passo falha, a API deve retornar erro ao usuario."""
+    def fail(*_, **__):
+        raise RuntimeError("error")
+    # Patching diretamente a funcao importada pelo modulo da API
+    monkeypatch.setattr(api, "executar_ciclo_criativo", fail)
+    client = TestClient(api.app, raise_server_exceptions=False)
+    resp = client.post("/ciclo/next")
+    assert resp.status_code == 500
+

--- a/tests/test_rh_auto.py
+++ b/tests/test_rh_auto.py
@@ -1,0 +1,12 @@
+import empresa_digital as ed
+import rh
+
+
+def test_rh_autocreates_when_shortage(reset_state):
+    """RH deve criar agentes quando ha saldo e tarefas pendentes."""
+    ed.criar_local("Sala", "", [])
+    ed.adicionar_tarefa("Nova")
+    ed.saldo = 10
+    rh.saldo = ed.saldo
+    rh.modulo_rh.verificar()
+    assert any(ag.funcao == "Executor" for ag in ed.agentes.values())

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -1,0 +1,25 @@
+import empresa_digital as ed
+import rh
+from ciclo_criativo import executar_ciclo_criativo
+
+
+def test_simulation_cycle_updates_state(reset_state):
+    """Executa um ciclo manualmente e verifica atualizações de saldo e eventos."""
+    ed.criar_local("Lab", "desc", ["pc"])
+    ed.criar_agente("Alice", "Ideacao", "gpt", "Lab")
+    ed.criar_agente("Bob", "Validador", "gpt", "Lab")
+    ed.adicionar_tarefa("T1")
+    ed.saldo = 20
+    rh.saldo = ed.saldo
+    rh.modulo_rh.verificar()
+
+    executar_ciclo_criativo()
+    for ag in list(ed.agentes.values()):
+        prompt = ed.gerar_prompt_decisao(ag)
+        resp = ed.enviar_para_llm(ag, prompt)
+        ed.executar_resposta(ag, resp)
+    result = ed.calcular_lucro_ciclo()
+
+    assert result["saldo"] != 0
+    assert ed.historico_saldo[-1] == result["saldo"]
+    assert ed.historico_eventos


### PR DESCRIPTION
## Summary
- add new pytest modules covering auto start, model selection and more
- document how to run the suite

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684756e3efcc83209973b706f0031483