### PR TITLE
Atualiza dashboard com dados automáticos

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Os principais endpoints retornam dados em JSON:
 - `POST /locais` – cria uma nova sala.
 - `PUT /locais/{nome}` – edita a sala existente.
 - `DELETE /locais/{nome}` – exclui a sala.
+- `GET /lucro` – retorna o saldo atual e o histórico acumulado.
 - `POST /ciclo/next` – executa um novo ciclo da simulação para todos os agentes.
 
 

--- a/api.py
+++ b/api.py
@@ -296,6 +296,12 @@ async def listar_eventos():
     return list(historico_eventos)
 
 
+@app.get("/lucro")
+async def obter_lucro():
+    """Expõe o saldo acumulado e o histórico de lucro."""
+    return {"saldo": saldo, "historico_saldo": historico_saldo}
+
+
 # ---------------------------- Controle da simulação ---------------------------
 @app.post("/ciclo/next")
 async def proximo_ciclo():


### PR DESCRIPTION
## Summary
- add `/lucro` endpoint to expose saldo and histórico
- fetch new data in the React dashboard on startup and periodically
- show errors if API calls fail and update timeline parsing
- document new endpoint in README

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684762997370832081601781de99c566