### PR TITLE
Add secret key ignore rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -193,3 +193,4 @@ cython_debug/
 .cursorignore
 .cursorindexingignore
 dashboard/node_modules/
+.openrouter_key

--- a/README.md
+++ b/README.md
@@ -183,7 +183,8 @@ python start_empresa.py
 Etapas realizadas pelo script:
 
 1. Caso não exista o arquivo `.openrouter_key`, pede a sua API Key e salva
-   localmente.
+   localmente. Esse arquivo armazena a chave e deve permanecer privado (já está
+   listado no `.gitignore`).
 2. Instala os pacotes Python listados em `requirements.txt`.
 3. Garante que as dependências do dashboard estejam instaladas (`npm install`).
 4. Inicia o backend na porta 8000 e aguarda ele ficar disponível.


### PR DESCRIPTION
## Summary
- prevent `.openrouter_key` from being committed
- mention in README that this file must remain private and is ignored

## Testing
- `pip install -r requirements.txt pytest`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847668e20f0832083b4193cdf7b6734