### PR TITLE
Busca opcional de chave da OpenRouter via .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+OPENROUTER_API_KEY=your_key_here

--- a/README.md
+++ b/README.md
@@ -212,6 +212,13 @@ Para executar todos os testes:
 # instalar dependências do backend e o pytest
 pip install -r requirements.txt pytest
 
+# defina a chave da OpenRouter
+export OPENROUTER_API_KEY=XXXX   # ou crie um arquivo .env com essa variável
+
+# exemplo:
+# cp .env.example .env
+# edite e depois execute `source .env`
+
 # rodar a suíte (é importante incluir o diretório raiz no PYTHONPATH)
 PYTHONPATH=. pytest -q
 ```

--- a/start_empresa.py
+++ b/start_empresa.py
@@ -16,6 +16,9 @@ DATA_LOCAIS = ROOT / "locais.json"
 
 def ensure_api_key() -> None:
     """Solicita e armazena a API Key da OpenRouter na primeira execucao."""
+    key = os.environ.get("OPENROUTER_API_KEY")
+    if key:
+        return
     if KEY_FILE.exists():
         key = KEY_FILE.read_text().strip()
     else:


### PR DESCRIPTION
## Summary
- get OPENROUTER_API_KEY from env or `.openrouter_key`
- adjust startup script to prefer env variable
- document how to set the key for testing
- provide `.env.example`

## Testing
- `pip install -r requirements.txt pytest`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684769ec8bbc8320916cb5ff50359e83