### PR TITLE
Add CLI utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,3 +237,22 @@ estão organizados em:
 Todos devem passar indicando que a empresa digital consegue se comportar de forma
 autônoma e resiliente.
 
+## CLI para automação
+
+Um utilitário de linha de comando está disponível no arquivo `cli.py`. Ele permite interagir com o backend sem a interface web, desde que o servidor esteja rodando.
+
+Exemplos:
+
+```bash
+# listar agentes
+python cli.py agentes
+
+# executar um ciclo
+python cli.py ciclo
+
+# obter os modelos gratuitos da OpenRouter
+python cli.py modelos
+```
+
+O utilitário lê a variável `OPENROUTER_API_KEY` ou o arquivo `.openrouter_key` para acessar endpoints que consultam a OpenRouter.
+

--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,86 @@
+import os
+import sys
+from pathlib import Path
+from getpass import getpass
+import argparse
+import requests
+
+ROOT = Path(__file__).parent
+KEY_FILE = ROOT / ".openrouter_key"
+DEFAULT_URL = os.environ.get("BACKEND_URL", "http://localhost:8000")
+
+
+def ensure_api_key() -> str:
+    """Garantir que a OpenRouter API Key esteja configurada."""
+    key = os.environ.get("OPENROUTER_API_KEY")
+    if key:
+        return key.strip()
+    if KEY_FILE.exists():
+        key = KEY_FILE.read_text().strip()
+    else:
+        key = getpass("Digite sua OpenRouter API Key: ")
+        KEY_FILE.write_text(key)
+    os.environ["OPENROUTER_API_KEY"] = key
+    return key
+
+
+def list_agents(base_url: str) -> None:
+    resp = requests.get(f"{base_url}/agentes", timeout=10)
+    resp.raise_for_status()
+    for ag in resp.json():
+        print(f"- {ag['nome']} ({ag['funcao']}) - {ag['local_atual']}")
+
+
+def list_rooms(base_url: str) -> None:
+    resp = requests.get(f"{base_url}/locais", timeout=10)
+    resp.raise_for_status()
+    for loc in resp.json():
+        print(f"- {loc['nome']}: {loc['descricao']}")
+
+
+def run_cycle(base_url: str) -> None:
+    resp = requests.post(f"{base_url}/ciclo/next", timeout=10)
+    resp.raise_for_status()
+    data = resp.json()
+    print("Saldo:", data["saldo"])
+    print("Eventos:")
+    for e in data.get("eventos", []):
+        print("  ", e)
+
+
+def list_models(base_url: str) -> None:
+    ensure_api_key()
+    resp = requests.get(f"{base_url}/modelos-livres", timeout=10)
+    resp.raise_for_status()
+    for m in resp.json():
+        print("-", m)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="CLI para Empresa Digital")
+    parser.add_argument(
+        "command",
+        choices=["agentes", "locais", "ciclo", "modelos"],
+        help="Acao a executar",
+    )
+    parser.add_argument(
+        "--url",
+        default=DEFAULT_URL,
+        help="URL base do backend (padrao: http://localhost:8000)",
+    )
+    args = parser.parse_args()
+
+    if args.command == "agentes":
+        list_agents(args.url)
+    elif args.command == "locais":
+        list_rooms(args.url)
+    elif args.command == "ciclo":
+        run_cycle(args.url)
+    elif args.command == "modelos":
+        list_models(args.url)
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a simple command-line interface for interacting with the backend
- document usage of the new CLI in README

## Testing
- `pip install -q -r requirements.txt pytest`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68476d19763c832097552e46fd89cf70