### PR TITLE
Implement backend-only initializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,23 @@ empresa..."**. Assim que o backend responde, a interface mostra as salas,
 agentes e um painel de eventos em tempo real demonstrando o raciocínio e as
 decisões de cada agente.
 
+## Inicializador para automação
+
+Para cenários sem interface visual há o script `start_backend.py`. Ele
+inicia apenas o backend FastAPI e já executa todo o processo de
+inicialização automática (salas, agentes, ciclo criativo, RH). Antes de
+executar, defina a variável `OPENROUTER_API_KEY` ou crie o arquivo
+`.openrouter_key` com sua chave. Não há qualquer prompt interativo.
+
+```bash
+export OPENROUTER_API_KEY=XXXX
+python start_backend.py
+```
+
+O backend ficará acessível em `http://localhost:8000` (ou na porta
+informada em `BACKEND_PORT`). Todos os endpoints podem ser consumidos pelo
+`cli.py` ou por agentes externos para testes e simulações automatizadas.
+
 ## Testes Automatizados
 
 Uma bateria de testes em `pytest` valida as partes isoladas do sistema e o comportamento integrado.

--- a/start_backend.py
+++ b/start_backend.py
@@ -1,0 +1,84 @@
+import os
+import sys
+import time
+from pathlib import Path
+import subprocess
+import requests
+
+ROOT = Path(__file__).parent
+BACKEND_PORT = os.environ.get("BACKEND_PORT", "8000")
+KEY_FILE = ROOT / ".openrouter_key"
+DATA_AGENTES = ROOT / "agentes.json"
+DATA_LOCAIS = ROOT / "locais.json"
+
+
+def ensure_api_key() -> None:
+    """Define OPENROUTER_API_KEY a partir de variavel ou arquivo."""
+    key = os.environ.get("OPENROUTER_API_KEY")
+    if key:
+        os.environ["OPENROUTER_API_KEY"] = key.strip()
+        return
+    if KEY_FILE.exists():
+        os.environ["OPENROUTER_API_KEY"] = KEY_FILE.read_text().strip()
+        return
+    raise RuntimeError(
+        "Defina OPENROUTER_API_KEY ou crie o arquivo .openrouter_key com a chave"
+    )
+
+
+def install_dependencies() -> None:
+    """Instala dependencias do backend se necessario."""
+    subprocess.run([sys.executable, "-m", "pip", "install", "-r", "requirements.txt"], check=True)
+
+
+def wait_backend(port: str, timeout: int = 30) -> bool:
+    url = f"http://localhost:{port}/locais"
+    for _ in range(timeout):
+        try:
+            requests.get(url, timeout=1)
+            return True
+        except Exception:
+            time.sleep(1)
+    return False
+
+
+def show_status(port: str) -> None:
+    try:
+        ag = requests.get(f"http://localhost:{port}/agentes", timeout=5).json()
+        loc = requests.get(f"http://localhost:{port}/locais", timeout=5).json()
+        print("Agentes:", ", ".join(a["nome"] for a in ag))
+        print("Salas:", ", ".join(l["nome"] for l in loc))
+    except Exception as exc:
+        print("Nao foi possivel obter informacoes iniciais:", exc)
+
+
+def main() -> None:
+    ensure_api_key()
+    install_dependencies()
+    print("Arquivos de dados serao armazenados em:")
+    print(f"  Agentes: {DATA_AGENTES}")
+    print(f"  Locais: {DATA_LOCAIS}")
+
+    backend_cmd = [sys.executable, "-m", "uvicorn", "api:app", "--host", "0.0.0.0", "--port", BACKEND_PORT]
+    print("Iniciando backend...")
+    backend = subprocess.Popen(backend_cmd)
+
+    try:
+        if not wait_backend(BACKEND_PORT):
+            print("Backend nao respondeu a tempo.")
+            backend.terminate()
+            backend.wait()
+            return
+        print(f"Backend rodando em http://localhost:{BACKEND_PORT}")
+        show_status(BACKEND_PORT)
+        print("Pressione Ctrl+C para encerrar.")
+        backend.wait()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        backend.terminate()
+        backend.wait()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `start_backend.py` to run only the FastAPI server
- document backend-only initializer in README for CLI automation

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68476f58fd988320a224e1dfc65ff4ae