### PR TITLE
Pin httpx 0.23 for stable tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ Para executar todos os testes:
 
 ```bash
 # instalar dependências do backend e o pytest
+# (o arquivo `requirements.txt` fixa o `httpx` na versão 0.23.x)
 pip install -r requirements.txt pytest
 
 # defina a chave da OpenRouter
@@ -239,6 +240,9 @@ export OPENROUTER_API_KEY=XXXX   # ou crie um arquivo .env com essa variável
 # rodar a suíte (é importante incluir o diretório raiz no PYTHONPATH)
 PYTHONPATH=. pytest -q
 ```
+
+O pacote `httpx` permanece travado na versão 0.23.x (menor que 0.24) para
+evitar problemas de compatibilidade durante os testes.
 
 O relatório exibirá quantos testes foram executados e possíveis falhas. Os testes
 estão organizados em:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 fastapi
 uvicorn
 requests
-httpx
+httpx==0.23.0


### PR DESCRIPTION
## Summary
- pin httpx to version 0.23.0
- document fixed httpx version under the Testes Automatizados section

## Testing
- `python -m pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684774ff10408320990a91f8841022cf